### PR TITLE
Add local CV markdown persistence and update deployment config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -31,3 +34,4 @@ jobs:
         with:
           folder: frontend/dist
           branch: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "1.0.0",
-  "homepage": "https://skyrim-line.github.io/Skyrim-Personal-Website",
+  "homepage": "https://skyrim-wu.github.io/Skyrim-Personal-Website",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/cv/CVToolbar.tsx
+++ b/frontend/src/components/cv/CVToolbar.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Download, Share2, Eye, Pencil } from "lucide-react";
+import { Download, Share2, Eye, Pencil, Save } from "lucide-react";
 import { toast } from "sonner";
 
 interface CVToolbarProps {
@@ -7,6 +7,8 @@ interface CVToolbarProps {
   mode: "edit" | "preview";
   onModeChange: (mode: "edit" | "preview") => void;
   onDownloadPDF: () => void;
+  onSave?: () => Promise<void>;
+  isSaving?: boolean;
   markdown: string;
 }
 
@@ -15,6 +17,8 @@ export function CVToolbar({
   mode,
   onModeChange,
   onDownloadPDF,
+  onSave,
+  isSaving = false,
   markdown,
 }: CVToolbarProps) {
   const handleShare = async () => {
@@ -63,6 +67,18 @@ export function CVToolbar({
         <Share2 className="w-3.5 h-3.5" />
         Share
       </Button>
+
+      {canEdit && onSave && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void onSave()}
+          disabled={isSaving}
+          className="h-8 px-3 text-xs gap-1.5">
+          <Save className="w-3.5 h-3.5" />
+          {isSaving ? "Saving..." : "Save"}
+        </Button>
+      )}
 
       <Button
         size="sm"

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
               <Mail className="w-5 h-5" />
             </a>
             <a
-              href="https://github.com/Skyrim-line"
+              href="https://github.com/Skyrim-Wu"
               target="_blank"
               rel="noopener noreferrer"
               className="text-gray-600 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"

--- a/frontend/src/data/defaultCv.md
+++ b/frontend/src/data/defaultCv.md
@@ -1,0 +1,68 @@
+# Simin Wu
+
+**Software Engineer · Full Stack Developer**
+
+contact@skyrimwu.me · GitHub: Skyrim-Wu · Sydney
+
+---
+
+## Summary
+
+Full-stack engineer with 3+ years of experience delivering production-grade web platforms and AI-powered products across frontend, backend, and cloud infrastructure. Strong track record of leading end-to-end execution, from product design and system architecture to deployment and commercial launch, with current work focused on intelligent workflow systems at EigenFlow AI.
+
+---
+
+## Experience
+
+### Tech Lead — Full Stack Developer
+**EigenFlow AI** · Mar 2025 – Present
+
+- Lead a 5-person engineering team end-to-end, owning technical direction, code reviews, sprint planning, and delivery milestones for a live B2B SaaS product in active commercial use
+- Sole owner of the entire frontend — architected, built, and shipped the production UI from zero without external contribution
+- Hands-on contributor across the full stack; actively co-developed backend services alongside the team, not a passive manager
+- Designed and owned the complete CI/CD pipeline and deployment workflow, taking the product from development to live commercial use
+
+---
+
+## Projects
+
+### EulerAI — Architecture Platform · [Live](https://construction.eulerai.au/)
+AI-powered platform for the architecture and construction industry, delivered as a full-stack engineer and team lead.
+
+- Led a 4-person engineering team through development and production launch
+- Built the RAG-powered backend retrieval system aligned to Australian ACC standards
+- Owned deployment and release delivery through to production
+- Designed and implemented the entire frontend UI and interaction experience
+
+### EulerAI — Official Website  [Live](https://www.eulerai.au/)
+Corporate marketing and product site for EulerAI, designed, built, and maintained independently.
+
+- Architected and developed both frontend and backend without external engineering support
+- Owned all CI/CD setup and production infrastructure, shipping to a live commercial environment
+
+### TheVineHK · [Live](https://www.thevinehk.com/)
+Commercial edtech web platform for a Hong Kong-based educational organisation, conceived and built solo.
+
+- Solely owned UI/UX design and frontend development from concept through production launch
+- Shipped a polished, production-ready product in active commercial use supporting real students and educators
+
+---
+
+## Skills
+
+**Languages:** TypeScript · JavaScript · Python · HTML · CSS
+
+**Frontend:** React · Vite · Tailwind CSS · Framer Motion 
+
+**Backend:** Node.js · REST APIs · RAG Systems · Retrieval Pipelines
+
+**Cloud & Infrastructure:** AWS · Kubernetes · Cloudflare · CI/CD · Production Deployment · Docker 
+
+**Tools:** Git · GitHub · Figma  · Claude Design
+
+---
+
+## Links
+
+- GitHub: [github.com/Skyrim-Wu](https://github.com/Skyrim-Wu)
+- Email: contact@skyrimwu.me

--- a/frontend/src/pages/CV.tsx
+++ b/frontend/src/pages/CV.tsx
@@ -4,85 +4,11 @@ import { useLocation } from "react-router-dom";
 import MDEditor from "@uiw/react-md-editor";
 import { CVPreview } from "@/components/cv/CVPreview";
 import { CVToolbar } from "@/components/cv/CVToolbar";
+import DEFAULT_CV from "@/data/defaultCv.md?raw";
 import { useTheme } from "@/components/theme/themeProvider";
 import Navbar from "@/components/layout/Header";
 import { Toaster } from "sonner";
-
-const DEFAULT_CV = `# Simin Wu
-
-**Software Engineer · Full Stack Developer**
-
-sm.wu@eigenflow.ai · GitHub: Skyrim-line · Hong Kong
-
----
-
-## Summary
-
-Full-stack engineer with a passion for building elegant, performant web applications and AI-powered products. Currently building the future of intelligent workflows at EigenFlow AI.
-
----
-
-## Experience
-
-### Tech Lead — Full Stack Developer
-**EigenFlow AI** · Mar 2025 – Present
-
-- Led a 5-person engineering team end-to-end, owning technical direction, code reviews, sprint planning, and delivery milestones for a live B2B SaaS product in active commercial use
-- Sole owner of the entire frontend — architected, built, and shipped the production UI from zero without external contribution
-- Hands-on contributor across the full stack; actively co-developed backend services alongside the team, not a passive manager
-- Designed and owned the complete CI/CD pipeline and deployment workflow, taking the product from development to live commercial use
-
----
-
-## Projects
-
-### EulerAI — Architecture Platform · [Live](https://construction.eulerai.au/)
-AI-powered platform for the architecture and construction industry, delivered as a full-stack engineer and team lead.
-
-- Led a 4-person engineering team through development and production launch
-- Built the RAG-powered backend retrieval system aligned to Australian ACC standards
-- Owned deployment and release delivery through to production
-- Designed and implemented the entire frontend UI and interaction experience
-
-### EulerAI — Official Website
-Corporate marketing and product site for EulerAI, designed, built, and maintained independently.
-
-- Architected and developed both frontend and backend without external engineering support
-- Owned all CI/CD setup and production infrastructure, shipping to a live commercial environment
-
-### TheVineHK · [Live](https://your-link-here)
-Commercial edtech web platform for a Hong Kong-based educational organisation, conceived and built solo.
-
-- Solely owned UI/UX design and frontend development from concept through production launch
-- Shipped a polished, production-ready product in active commercial use supporting real students and educators
-
----
-
-## Skills
-
-**Languages:** TypeScript · JavaScript · Python · HTML · CSS
-
-**Frontend:** React · Vite · Tailwind CSS · Framer Motion · Radix UI
-
-**Backend:** Node.js · REST APIs · RAG Systems · Retrieval Pipelines
-
-**Cloud & Infrastructure:** AWS · Kubernetes · Cloudflare · CI/CD · Production Deployment
-
-**Tools:** Git · GitHub · VS Code · Figma
-
----
-
-## Education
-
-Hong Kong University of Science and Technology (HKUST)
-
----
-
-## Links
-
-- GitHub: [github.com/Skyrim-line](https://github.com/Skyrim-line)
-- Email: sm.wu@eigenflow.ai
-`;
+import { toast } from "sonner";
 
 const STORAGE_KEY = "cv-content";
 
@@ -119,6 +45,7 @@ export default function CV() {
     loadInitialMarkdown(location.search, canEdit),
   );
   const [mode, setMode] = useState<"edit" | "preview">(canEdit ? "edit" : "preview");
+  const [isSaving, setIsSaving] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -146,6 +73,56 @@ export default function CV() {
     window.print();
   }, []);
 
+  const handleSaveToFile = useCallback(async () => {
+    if (!canEdit) {
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const response = await fetch("/__cv/save", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ markdown }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to save CV markdown.");
+      }
+
+      localStorage.setItem(STORAGE_KEY, markdown);
+      toast.success("CV markdown saved to defaultCv.md", {
+        duration: 5000,
+      });
+    } catch {
+      toast.error("Failed to save CV markdown to file.", {
+        duration: 6000,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [canEdit, markdown]);
+
+  useEffect(() => {
+    if (!canEdit) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        if (!isSaving) {
+          void handleSaveToFile();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [canEdit, handleSaveToFile, isSaving]);
+
   return (
     <div id="cv-print-root" className="min-h-screen bg-gray-50 dark:bg-gray-950 flex flex-col">
       <Toaster position="top-center" richColors />
@@ -158,9 +135,11 @@ export default function CV() {
         </h2>
         <CVToolbar
           canEdit={canEdit}
+          isSaving={isSaving}
           mode={mode}
           onModeChange={setMode}
           onDownloadPDF={handleDownloadPDF}
+          onSave={handleSaveToFile}
           markdown={markdown}
         />
       </div>

--- a/frontend/src/pages/ContactMe.tsx
+++ b/frontend/src/pages/ContactMe.tsx
@@ -32,7 +32,7 @@ export default function ContactMe() {
           </div>
           <div className="flex flex-wrap gap-4">
             <a
-              href="https://github.com/Skyrim-line"
+              href="https://github.com/Skyrim-Wu"
               target="_blank"
               rel="noopener noreferrer"
               className="p-3 rounded-full !bg-white dark:!bg-gray-800 shadow-md hover:shadow-lg transition-all hover:scale-105">

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,51 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export default defineConfig({
-  base: "/Skyrim-Personal-Website/",
-  plugins: [react(), tailwindcss()],
+  base: "./",
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: "cv-markdown-save",
+      configureServer(server) {
+        server.middlewares.use("/__cv/save", async (req, res) => {
+          if (req.method !== "POST") {
+            res.statusCode = 405;
+            res.end("Method Not Allowed");
+            return;
+          }
+
+          let body = "";
+          req.on("data", (chunk) => {
+            body += chunk;
+          });
+
+          req.on("end", async () => {
+            try {
+              const payload = JSON.parse(body) as { markdown?: string };
+              if (typeof payload.markdown !== "string") {
+                res.statusCode = 400;
+                res.end("Invalid markdown payload");
+                return;
+              }
+
+              const targetFile = path.resolve(__dirname, "src/data/defaultCv.md");
+              await writeFile(targetFile, payload.markdown, "utf8");
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ ok: true }));
+            } catch {
+              res.statusCode = 500;
+              res.end("Failed to save markdown");
+            }
+          });
+        });
+      },
+    },
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## Summary
- Extracted the default CV content into `frontend/src/data/defaultCv.md` and switched the CV page to load it as raw markdown.
- Added a dev-only save flow so local edits can be written back to `defaultCv.md`, including a `Save` action and `Alt+S` shortcut.
- Kept production CV access read-only while preserving share and PDF export.
- Updated GitHub Pages deployment settings for the renamed `Skyrim-Wu` repository and added the required deploy token permissions.
- Refreshed public GitHub links and CV content to match the new profile details.

## Testing
- `npm run build`
- Verified the CV page still builds successfully with the new markdown import and save workflow.